### PR TITLE
cmdline typo fix, algorithn => algorithm in line 55.

### DIFF
--- a/src/stanrun/cmdline.jl
+++ b/src/stanrun/cmdline.jl
@@ -52,7 +52,7 @@ function cmdline(m::OptimizeModel, id)
             if m.algorithm == :lbfgs
                 cmd = `$cmd history_size=$(m.history_size)`
             end
-        elseif m.algorithn == :newtom
+        elseif m.algorithm == :newtom
             cmd = `$cmd iter=$(m.iter)`
             if m.save_history
                 cmd = `$cmd save_iterations=1`

--- a/src/stanrun/cmdline.jl
+++ b/src/stanrun/cmdline.jl
@@ -52,7 +52,7 @@ function cmdline(m::OptimizeModel, id)
             if m.algorithm == :lbfgs
                 cmd = `$cmd history_size=$(m.history_size)`
             end
-        elseif m.algorithm == :newtom
+        elseif m.algorithm == :newton
             cmd = `$cmd iter=$(m.iter)`
             if m.save_history
                 cmd = `$cmd save_iterations=1`


### PR DESCRIPTION
PR for fixing typo in src/stanrun/cmdline.jl, algorithn => algorithm in line 55